### PR TITLE
add service account get and list and cani endpoint

### DIFF
--- a/lib/controllers/auth_controller.go
+++ b/lib/controllers/auth_controller.go
@@ -1,14 +1,55 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/tgs266/fleet/lib/api"
 	"github.com/tgs266/fleet/lib/auth"
 	"github.com/tgs266/fleet/lib/client"
+	"github.com/tgs266/fleet/lib/errors"
+	v1 "k8s.io/api/authorization/v1"
 )
+
+func CanI(c *fiber.Ctx, client *client.ClientManager) error {
+	K8, err := client.Client(c)
+	if err != nil {
+		return err
+	}
+
+	name := c.Query("name")
+	namespace := c.Query("namespace")
+	verb := c.Query("verb")
+	resource := c.Query("resource")
+
+	response, err := K8.K8.AuthorizationV1().SelfSubjectAccessReviews().Create(context.TODO(), &v1.SelfSubjectAccessReview{
+		Spec: v1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &v1.ResourceAttributes{
+				Namespace: namespace,
+				Name:      name,
+				Resource:  fmt.Sprintf("%ss", strings.ToLower(resource)),
+				Verb:      strings.ToLower(verb),
+			},
+		},
+	}, metaV1.CreateOptions{})
+
+	if err != nil {
+		return errors.ParseInternalError(err)
+	}
+	resp := struct {
+		Allowed bool `json:"allowed"`
+	}{
+		Allowed: response.Status.Allowed,
+	}
+
+	return c.JSON(resp)
+}
 
 func Login(c *fiber.Ctx, client *client.ClientManager) error {
 	body := new(auth.LoginRequest)

--- a/lib/controllers/routes.go
+++ b/lib/controllers/routes.go
@@ -32,7 +32,13 @@ func initializeServiceRoutes(app *api.API) {
 	app.Get("/api/v1/services/:namespace/:name", GetService)
 }
 
+func initializeServiceAccountRoutes(app *api.API) {
+	app.Get("/api/v1/serviceaccounts/:namespace/", GetServiceAccounts)
+	app.Get("/api/v1/serviceaccounts/:namespace/:name", GetServiceAccount)
+}
+
 func initializeOtherRoutes(app *api.API) {
+	app.Get("/api/v1/auth/cani", CanI)
 	app.Post("/api/v1/auth/login", Login)
 	app.Post("/api/v1/auth/refresh", Refresh)
 	app.Get("/api/v1/images", GetAllImages)
@@ -56,5 +62,6 @@ func InitializeRoutes(app *api.API) {
 	initializeDeploymentRoutes(app)
 	initializeNodeRoutes(app)
 	initializeServiceRoutes(app)
+	initializeServiceAccountRoutes(app)
 	initializeOtherRoutes(app)
 }

--- a/lib/controllers/serviceaccount_controller.go
+++ b/lib/controllers/serviceaccount_controller.go
@@ -1,0 +1,43 @@
+package controllers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/tgs266/fleet/lib/client"
+	"github.com/tgs266/fleet/lib/errors"
+	"github.com/tgs266/fleet/lib/kubernetes/resources/serviceaccount"
+	"github.com/tgs266/fleet/lib/kubernetes/types"
+	"github.com/tgs266/fleet/lib/shared"
+)
+
+func GetServiceAccounts(c *fiber.Ctx, client *client.ClientManager) error {
+	K8, err := client.Client(c)
+	if err != nil {
+		return err
+	}
+
+	namespace := shared.GetNamespace(c.Params("namespace"))
+
+	dataSelector := types.BuildDataRequest(c).BuildDataSelector().AddIgnoreSystemNamespace()
+
+	accounts, err := serviceaccount.List(K8, namespace, dataSelector)
+	if err != nil {
+		return err
+	}
+	return c.Status(fiber.StatusOK).JSON(accounts)
+}
+
+func GetServiceAccount(c *fiber.Ctx, client *client.ClientManager) error {
+	K8, err := client.Client(c)
+	if err != nil {
+		return err
+	}
+
+	namespace := shared.GetNamespace(c.Params("namespace"))
+	name := c.Params("name")
+
+	sa, err := serviceaccount.Get(K8, namespace, name)
+	if err != nil {
+		return errors.ParseInternalError(err)
+	}
+	return c.Status(fiber.StatusOK).JSON(sa)
+}

--- a/lib/controllers/serviceaccount_controller_test.go
+++ b/lib/controllers/serviceaccount_controller_test.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServiceAccountList(t *testing.T) {
+	app := setupApp()
+	app.Get("/:namespace", GetServiceAccounts)
+
+	req := httptest.NewRequest("GET", "/asdf", nil)
+
+	app.Test(req)
+}
+
+func TestGetServiceAccount(t *testing.T) {
+	app := setupApp()
+	app.Get("/:namespace/:name", GetServiceAccount)
+
+	req := httptest.NewRequest("GET", "/asdf/asdf?sortBy=name,a", nil)
+
+	app.Test(req)
+}

--- a/lib/kubernetes/channels/serviceaccount.go
+++ b/lib/kubernetes/channels/serviceaccount.go
@@ -1,0 +1,30 @@
+package channels
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ServiceAccountListChannel struct {
+	List  chan *v1.ServiceAccountList
+	Error chan error
+}
+
+func GetServiceAccountListChannel(client kubernetes.Interface, namespace string, options metaV1.ListOptions, numReads int) *ServiceAccountListChannel {
+	channel := &ServiceAccountListChannel{
+		List:  make(chan *v1.ServiceAccountList, numReads),
+		Error: make(chan error, numReads),
+	}
+
+	go func() {
+		list, err := client.CoreV1().ServiceAccounts(namespace).List(context.TODO(), options)
+		for i := 0; i < numReads; i++ {
+			channel.List <- list
+			channel.Error <- err
+		}
+	}()
+	return channel
+}

--- a/lib/kubernetes/resources/serviceaccount/access.go
+++ b/lib/kubernetes/resources/serviceaccount/access.go
@@ -1,0 +1,1 @@
+package serviceaccount

--- a/lib/kubernetes/resources/serviceaccount/comparable.go
+++ b/lib/kubernetes/resources/serviceaccount/comparable.go
@@ -1,0 +1,40 @@
+package serviceaccount
+
+import (
+	"github.com/tgs266/fleet/lib/kubernetes/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+type saComparable struct {
+	sa v1.ServiceAccount
+}
+
+func (comp saComparable) Get(field types.Property) types.Comparable {
+	switch field {
+	case types.NameProperty:
+		return types.ComparableString(comp.sa.Name)
+	case types.NamespaceProperty:
+		return types.ComparableString(comp.sa.Namespace)
+	case types.CreatedAtProperty:
+		return types.ComparableInt64(comp.sa.CreationTimestamp.UnixMilli())
+	}
+	return types.ComparableString("")
+}
+
+func ToComparable(accounts *v1.ServiceAccountList) []types.ComparableType {
+	comps := []types.ComparableType{}
+	for _, sa := range accounts.Items {
+		comps = append(comps, saComparable{sa: sa})
+	}
+	return comps
+}
+
+func FromComparable(accounts []types.ComparableType) *v1.ServiceAccountList {
+	list := []v1.ServiceAccount{}
+	for _, sa := range accounts {
+		list = append(list, sa.(saComparable).sa)
+	}
+	return &v1.ServiceAccountList{
+		Items: list,
+	}
+}

--- a/lib/kubernetes/resources/serviceaccount/get.go
+++ b/lib/kubernetes/resources/serviceaccount/get.go
@@ -1,0 +1,17 @@
+package serviceaccount
+
+import (
+	"context"
+
+	"github.com/tgs266/fleet/lib/errors"
+	"github.com/tgs266/fleet/lib/kubernetes"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Get(K8 *kubernetes.K8Client, namespace string, name string) (*ServiceAccount, error) {
+	sa, err := K8.K8.CoreV1().ServiceAccounts(namespace).Get(context.Background(), name, metaV1.GetOptions{})
+	if err != nil {
+		return nil, errors.ParseInternalError(err)
+	}
+	return BuildServiceAccount(sa), nil
+}

--- a/lib/kubernetes/resources/serviceaccount/get_test.go
+++ b/lib/kubernetes/resources/serviceaccount/get_test.go
@@ -1,0 +1,77 @@
+package serviceaccount
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tgs266/fleet/lib/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGet(t *testing.T) {
+	testCases := []struct {
+		name            string
+		accounts        []runtime.Object
+		targetName      string
+		targetNamespace string
+		expectedCount   int
+	}{
+		{
+			name: "list_accounts1",
+			accounts: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf",
+						Namespace: "asdf",
+					},
+				},
+			},
+			targetName:      "asdf",
+			targetNamespace: "asdf",
+			expectedCount:   1,
+		},
+		{
+			name: "list_accounts2",
+			accounts: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf1",
+						Namespace: "asdf",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf2",
+						Namespace: "asdf",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf2",
+						Namespace: "asdf-different",
+					},
+				},
+			},
+			targetName:      "asdf2",
+			targetNamespace: "asdf",
+			expectedCount:   2,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClientset := fake.NewSimpleClientset(test.accounts...)
+			sa, err := Get(&kubernetes.K8Client{
+				K8: fakeClientset,
+			}, test.targetNamespace, test.targetName)
+
+			assert.Nil(t, err)
+			assert.Equal(t, test.targetNamespace, sa.Meta.Namespace)
+			assert.Equal(t, test.targetName, sa.Meta.Name)
+
+		})
+	}
+}

--- a/lib/kubernetes/resources/serviceaccount/list.go
+++ b/lib/kubernetes/resources/serviceaccount/list.go
@@ -23,15 +23,22 @@ func List(K8 *kubernetes.K8Client, namespace string, selector *types.DataSelecto
 		serviceAccounts = FromComparable(selector.Items)
 	}
 
-	resp := []ServiceAccountMeta{}
+	items := []ServiceAccountMeta{}
 	for _, sa := range serviceAccounts.Items {
-		resp = append(resp, BuildServiceAccountMeta(&sa))
+		items = append(items, BuildServiceAccountMeta(&sa))
+	}
+	resp := &types.PaginationResponse{
+		Items: items,
+		Count: len(items),
 	}
 
-	return &types.PaginationResponse{
-		Items:  resp,
-		Count:  len(resp),
-		Total:  selector.TotalItemCount,
-		Offset: selector.Offset,
-	}, nil
+	if selector != nil {
+		resp.Total = selector.TotalItemCount
+		resp.Offset = selector.Offset
+	} else {
+		resp.Total = resp.Count
+		resp.Offset = 0
+	}
+
+	return resp, nil
 }

--- a/lib/kubernetes/resources/serviceaccount/list.go
+++ b/lib/kubernetes/resources/serviceaccount/list.go
@@ -1,0 +1,37 @@
+package serviceaccount
+
+import (
+	"github.com/tgs266/fleet/lib/errors"
+	"github.com/tgs266/fleet/lib/kubernetes"
+	"github.com/tgs266/fleet/lib/kubernetes/channels"
+	"github.com/tgs266/fleet/lib/kubernetes/types"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func List(K8 *kubernetes.K8Client, namespace string, selector *types.DataSelector) (*types.PaginationResponse, error) {
+	saChannelList := channels.GetServiceAccountListChannel(K8.K8, namespace, metaV1.ListOptions{}, 1)
+
+	serviceAccounts := <-saChannelList.List
+	err := <-saChannelList.Error
+	if err != nil {
+		return nil, errors.ParseInternalError(err)
+	}
+
+	if selector != nil {
+		saComps := ToComparable(serviceAccounts)
+		selector.Execute(saComps)
+		serviceAccounts = FromComparable(selector.Items)
+	}
+
+	resp := []ServiceAccountMeta{}
+	for _, sa := range serviceAccounts.Items {
+		resp = append(resp, BuildServiceAccountMeta(&sa))
+	}
+
+	return &types.PaginationResponse{
+		Items:  resp,
+		Count:  len(resp),
+		Total:  selector.TotalItemCount,
+		Offset: selector.Offset,
+	}, nil
+}

--- a/lib/kubernetes/resources/serviceaccount/list_test.go
+++ b/lib/kubernetes/resources/serviceaccount/list_test.go
@@ -1,0 +1,78 @@
+package serviceaccount
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tgs266/fleet/lib/kubernetes"
+	"github.com/tgs266/fleet/lib/kubernetes/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestListMetas(t *testing.T) {
+	testCases := []struct {
+		name            string
+		accounts        []runtime.Object
+		selector        *types.DataSelector
+		targetNamespace string
+		expectedCount   int
+	}{
+		{
+			name: "list_accounts1",
+			accounts: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf",
+						Namespace: "asdf",
+					},
+				},
+			},
+			selector: &types.DataSelector{
+				SortBy: []types.SortBy{
+					{
+						Property:  types.NameProperty,
+						Ascending: false,
+					},
+				},
+			},
+			targetNamespace: "asdf",
+			expectedCount:   1,
+		},
+		{
+			name: "list_accounts2",
+			accounts: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf1",
+						Namespace: "asdf",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "asdf2",
+						Namespace: "asdf",
+					},
+				},
+			},
+			selector:        nil,
+			targetNamespace: "asdf",
+			expectedCount:   2,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClientset := fake.NewSimpleClientset(test.accounts...)
+			metas, err := List(&kubernetes.K8Client{
+				K8: fakeClientset,
+			}, test.targetNamespace, test.selector)
+
+			assert.Nil(t, err)
+			assert.Len(t, metas.Items, test.expectedCount)
+
+		})
+	}
+}

--- a/lib/kubernetes/resources/serviceaccount/types.go
+++ b/lib/kubernetes/resources/serviceaccount/types.go
@@ -1,0 +1,37 @@
+package serviceaccount
+
+import (
+	"github.com/tgs266/fleet/lib/kubernetes/common"
+	v1 "k8s.io/api/core/v1"
+)
+
+type ServiceAccountMeta struct {
+	UID         string            `json:"uid"`
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	CreatedAt   uint              `json:"createdAt"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+type ServiceAccount struct {
+	Meta ServiceAccountMeta `json:",inline"`
+}
+
+func BuildServiceAccountMeta(sa *v1.ServiceAccount) ServiceAccountMeta {
+	return ServiceAccountMeta{
+		Name:        sa.Name,
+		Namespace:   sa.Namespace,
+		CreatedAt:   uint(sa.CreationTimestamp.UnixMilli()),
+		UID:         string(sa.UID),
+		Labels:      sa.Labels,
+		Annotations: common.CleanAnnotations(sa.GetAnnotations()),
+	}
+}
+
+func BuildServiceAccount(sa *v1.ServiceAccount) *ServiceAccount {
+	meta := BuildServiceAccountMeta(sa)
+	return &ServiceAccount{
+		Meta: meta,
+	}
+}

--- a/lib/kubernetes/test_helper.go
+++ b/lib/kubernetes/test_helper.go
@@ -36,6 +36,27 @@ func GetTestClient() *K8Client {
 		}),
 	}
 
+	serviceAccounts := []runtime.Object{
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sa1",
+				Namespace: "namespace1",
+				Labels: map[string]string{
+					"k8s-app": "asdf",
+				},
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sa2",
+				Namespace: "namespace1",
+				Labels: map[string]string{
+					"k8s-app": "asdf",
+				},
+			},
+		},
+	}
+
 	deployments := []runtime.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -59,7 +80,13 @@ func GetTestClient() *K8Client {
 		},
 	}
 
-	client := fake.NewSimpleClientset(append(append(nodes, deployments...), pods...)...)
+	objs := []runtime.Object{}
+	objs = append(objs, deployments...)
+	objs = append(objs, pods...)
+	objs = append(objs, nodes...)
+	objs = append(objs, serviceAccounts...)
+
+	client := fake.NewSimpleClientset(objs...)
 	return &K8Client{
 		K8: client,
 	}

--- a/lib/main.go
+++ b/lib/main.go
@@ -60,7 +60,7 @@ func parseFlags() Flags {
 func setupBackend(flags Flags) *api.API {
 	manager := client.NewClientManager(*flags.useAuth)
 
-	if flags.oidcIssuerUrl != nil {
+	if *flags.oidcIssuerUrl != "" {
 		err := manager.InitializeOIDC(oidc.OIDCConfig{
 			IssuerURL:        *flags.oidcIssuerUrl,
 			ClientID:         *flags.oidcClientId,
@@ -69,13 +69,6 @@ func setupBackend(flags Flags) *api.API {
 			UseOfflineAccess: true,
 		})
 		if err != nil {
-			logging.INFO(oidc.OIDCConfig{
-				IssuerURL:        *flags.oidcIssuerUrl,
-				ClientID:         *flags.oidcClientId,
-				ClientSecret:     *flags.oidcClientSecret,
-				Host:             *flags.host,
-				UseOfflineAccess: true,
-			})
 			logging.ERROR(err)
 		}
 	}
@@ -107,7 +100,7 @@ func setupBackend(flags Flags) *api.API {
 	logging.INFO("initializing routing")
 	controllers.InitializeRoutes(app)
 
-	if flags.oidcIssuerUrl != nil {
+	if *flags.oidcIssuerUrl != "" {
 		logging.INFO("initializing OIDC routing")
 		controllers.AddOIDCRoutes(app)
 	} else {

--- a/lib/main_test.go
+++ b/lib/main_test.go
@@ -16,8 +16,14 @@ func TestSetupBackend(t *testing.T) {
 	logging.Init(logging.LVL_INFO)
 
 	useAuth := true
+	str := "asdf"
+
 	flags := Flags{
-		useAuth: &useAuth,
+		useAuth:          &useAuth,
+		oidcIssuerUrl:    &str,
+		oidcClientId:     &str,
+		oidcClientSecret: &str,
+		host:             &str,
 	}
 
 	setupBackend(flags)
@@ -38,6 +44,7 @@ func TestSetupBackend2(t *testing.T) {
 		oidcIssuerUrl:    &str,
 		oidcClientId:     &str,
 		oidcClientSecret: &str,
+		host:             &str,
 	}
 
 	setupBackend(flags)

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "less": "^4.1.2",
     "lint-staged": "^12.3.7",
     "mini-css-extract-plugin": "^2.6.0",
-    "msw": "^0.39.2",
     "source-map-loader": "^3.0.1",
     "ts-jest": "^27.1.3",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
+    "msw": "^0.39.2",
     "@blueprintjs/core": "^4.1.1",
     "@blueprintjs/popover2": "^1.1.1",
     "@blueprintjs/select": "^4.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import PodList from './views/PodList/PodList';
 import Namespace from './views/Namespace/Namespace';
 import NamespaceList from './views/NamespaceList/NamespaceList';
 import ServiceList from './views/ServiceList/ServiceList';
+import ServiceAccountList from './views/ServiceAccountList/ServiceAccountList';
 
 function getCookie(name: string) {
     const value = `; ${document.cookie}`;
@@ -64,6 +65,8 @@ function App() {
 
                 <Route path="namespaces" element={<NamespaceList />} />
                 <Route path="namespaces/:namespace" element={<Namespace />} />
+
+                <Route path="serviceAccounts/" element={<ServiceAccountList />} />
             </Route>
         </Routes>
     );

--- a/src/layouts/SideNavigation.tsx
+++ b/src/layouts/SideNavigation.tsx
@@ -1,50 +1,70 @@
 import * as React from 'react';
+import Auth from '../services/auth.service';
 import SideNavButton, { NavButton } from './SideNavButton';
 
+const navBtns: NavButton[] = [
+    {
+        target: '/',
+        id: 'Home',
+        icon: 'home',
+        activeSelector: (pathname: string) =>
+            pathname.startsWith('/') && pathname.endsWith('/') && pathname.length === 1,
+    },
+    {
+        target: '/namespaces',
+        icon: 'projects',
+        name: 'Namespaces',
+        id: 'Namespaces',
+    },
+    {
+        target: '/nodes',
+        icon: 'control',
+        name: 'Nodes',
+        id: 'Nodes',
+    },
+    {
+        target: '/deployments',
+        icon: 'applications',
+        name: 'Deployments',
+        id: 'Deployments',
+    },
+    {
+        target: '/pods',
+        icon: 'group-objects',
+        name: 'Pods',
+        id: 'Pods',
+    },
+    {
+        target: '/services',
+        icon: 'globe-network',
+        name: 'Services',
+        id: 'Services',
+    },
+];
+
 export default function SideNavigation() {
-    const navBtns: NavButton[] = [
-        {
-            target: '/',
-            id: 'Home',
-            icon: 'home',
-            activeSelector: (pathname: string) =>
-                pathname.startsWith('/') && pathname.endsWith('/') && pathname.length === 1,
-        },
-        {
-            target: '/namespaces',
-            icon: 'projects',
-            name: 'Namespaces',
-            id: 'Namespaces',
-        },
-        {
-            target: '/nodes',
-            icon: 'control',
-            name: 'Nodes',
-            id: 'Nodes',
-        },
-        {
-            target: '/deployments',
-            icon: 'applications',
-            name: 'Deployments',
-            id: 'Deployments',
-        },
-        {
-            target: '/pods',
-            icon: 'group-objects',
-            name: 'Pods',
-            id: 'Pods',
-        },
-        {
-            target: '/services',
-            icon: 'globe-network',
-            name: 'Services',
-            id: 'Services',
-        },
-    ];
+    const [buttons, setButtons] = React.useState(navBtns);
+
+    React.useEffect(() => {
+        Auth.canI('serviceaccounts', 'list').then((r) => {
+            if (r.data.allowed) {
+                setButtons([
+                    ...buttons,
+                    {
+                        target: '/serviceaccounts',
+                        icon: 'people',
+                        name: 'Service Accounts',
+                        id: 'ServiceAccounts',
+                    },
+                ]);
+            }
+        });
+    }, []);
+
     return (
         <div style={{ WebkitUserSelect: 'none' }}>
             <div className="sidebar">
-                {navBtns.map((btn) => (
+                {buttons.map((btn) => (
                     <SideNavButton key={btn.name} {...btn} />
                 ))}
             </div>

--- a/src/models/serviceaccount.model.ts
+++ b/src/models/serviceaccount.model.ts
@@ -1,0 +1,5 @@
+import { NamespacedMeta } from './base';
+
+export interface ServiceAccountMeta extends NamespacedMeta {}
+
+export interface ServiceAccount extends ServiceAccountMeta {}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -32,6 +32,20 @@ export default class Auth {
         name?: string,
         namespace?: string
     ): Promise<AxiosResponse<{ allowed: boolean }>> {
+        if (process.env.TEST_ENV) {
+            return new Promise((resolve) => {
+                const x: AxiosResponse<{ allowed: boolean }> = {
+                    config: {},
+                    status: 200,
+                    statusText: 'asdf',
+                    headers: {},
+                    data: {
+                        allowed: true,
+                    },
+                };
+                resolve(x);
+            });
+        }
         return axios.get(`${Auth.base}/cani`, { params: { resource, verb, name, namespace } });
     }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -25,4 +25,13 @@ export default class Auth {
     static canUseOIDC(): Promise<AxiosResponse<{ available: boolean }>> {
         return axios.get(`${Auth.base}/oauth2`);
     }
+
+    static canI(
+        resource: string,
+        verb: string,
+        name?: string,
+        namespace?: string
+    ): Promise<AxiosResponse<{ allowed: boolean }>> {
+        return axios.get(`${Auth.base}/cani`, { params: { resource, verb, name, namespace } });
+    }
 }

--- a/src/services/axios.service.tsx
+++ b/src/services/axios.service.tsx
@@ -17,17 +17,15 @@ export function getWSUrl(path: string): string {
 const api = axios.create();
 let dialog: HTMLDivElement = null;
 
-if (!process.env.TEST_ENV) {
-    api.defaults.baseURL = `${window.location.href.replace(window.location.hash, '')}`;
-    api.interceptors.request.use((config: AxiosRequestConfig<any>) => {
-        const token = localStorage.getItem('jwe');
-        if (token) {
-            config.headers.jweToken = token;
-        }
+api.defaults.baseURL = `${window.location.href.replace(window.location.hash, '')}`;
+api.interceptors.request.use((config: AxiosRequestConfig<any>) => {
+    const token = localStorage.getItem('jwe');
+    if (token) {
+        config.headers.jweToken = token;
+    }
 
-        return config;
-    });
-}
+    return config;
+});
 
 api.interceptors.response.use(
     (response: AxiosResponse<any, any> | Promise<AxiosResponse<any, any>>) => response,

--- a/src/services/axios.service.tsx
+++ b/src/services/axios.service.tsx
@@ -17,16 +17,17 @@ export function getWSUrl(path: string): string {
 const api = axios.create();
 let dialog: HTMLDivElement = null;
 
-api.defaults.baseURL = `${window.location.href.replace(window.location.hash, '')}`;
+if (!process.env.TEST_ENV) {
+    api.defaults.baseURL = `${window.location.href.replace(window.location.hash, '')}`;
+    api.interceptors.request.use((config: AxiosRequestConfig<any>) => {
+        const token = localStorage.getItem('jwe');
+        if (token) {
+            config.headers.jweToken = token;
+        }
 
-api.interceptors.request.use((config: AxiosRequestConfig<any>) => {
-    const token = localStorage.getItem('jwe');
-    if (token) {
-        config.headers.jweToken = token;
-    }
-
-    return config;
-});
+        return config;
+    });
+}
 
 api.interceptors.response.use(
     (response: AxiosResponse<any, any> | Promise<AxiosResponse<any, any>>) => response,

--- a/src/services/k8.service.ts
+++ b/src/services/k8.service.ts
@@ -8,6 +8,7 @@ import Nodes from './k8/node.service';
 import Namespaces from './k8/namespace.service';
 import { JSONObjectType } from '../models/json.model';
 import api from './axios.service';
+import ServiceAccounts from './k8/serviceaccount.service';
 
 export default class K8 {
     static deployments = Deployments;
@@ -23,6 +24,8 @@ export default class K8 {
     static nodes = Nodes;
 
     static namespaces = Namespaces;
+
+    static serviceAccounts = ServiceAccounts;
 
     static getFilterProperties(): Promise<AxiosResponse<JSONObjectType<string>>> {
         return api.get('/api/v1/filters/properties');

--- a/src/services/k8/serviceaccount.service.ts
+++ b/src/services/k8/serviceaccount.service.ts
@@ -1,0 +1,28 @@
+import { AxiosResponse } from 'axios';
+import { TableSort } from '../../components/SortableTableHeaderCell';
+import { PaginationResponse } from '../../models/base';
+import { ServiceAccount, ServiceAccountMeta } from '../../models/serviceaccount.model';
+import getSortBy from '../../utils/sort';
+import api from '../axios.service';
+
+export default class ServiceAccounts {
+    static base = '/api/v1/serviceaccounts';
+
+    static getServiceAccount(
+        name: string,
+        namespace?: string
+    ): Promise<AxiosResponse<ServiceAccount>> {
+        return api.get(`${ServiceAccounts.base}/${namespace}/${name}`);
+    }
+
+    static getServiceAccounts(
+        namespace?: string,
+        sort?: TableSort,
+        offset?: number,
+        pageSize?: number
+    ): Promise<AxiosResponse<PaginationResponse<ServiceAccountMeta>>> {
+        return api.get(`${ServiceAccounts.base}/${namespace || '_all_'}/`, {
+            params: { sortBy: getSortBy(sort), offset, pageSize },
+        });
+    }
+}

--- a/src/testing/setup.js
+++ b/src/testing/setup.js
@@ -1,7 +1,22 @@
 const nodeCrypto = require('crypto');
+const msw = require('msw');
+const { setupServer } = require('msw/node');
+const { default: Auth } = require('../services/auth.service');
+
+process.env.TEST_ENV = true;
 
 window.crypto = {
     getRandomValues(buffer) {
         return nodeCrypto.randomFillSync(buffer);
     },
 };
+
+const server = setupServer(
+    msw.rest.get(`${Auth.base}/cani`, (req, res, ctx) => res(ctx.json({ allowed: true })))
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+export default server;

--- a/src/utils/urljoin.js
+++ b/src/utils/urljoin.js
@@ -4,29 +4,9 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable prefer-rest-params */
 /* eslint-disable no-param-reassign */
-function normalize(strArray) {
+
+function joinLoop(strArray) {
     const resultArray = [];
-    if (strArray.length === 0) {
-        return '';
-    }
-
-    if (typeof strArray[0] !== 'string') {
-        throw new TypeError(`Url must be a string. Received ${strArray[0]}`);
-    }
-
-    // If the first part is a plain protocol, we combine it with the next part.
-    if (strArray[0].match(/^[^/:]+:\/*$/) && strArray.length > 1) {
-        const first = strArray.shift();
-        strArray[0] = first + strArray[0];
-    }
-
-    // There must be two or three slashes in the file protocol, two slashes in anything else.
-    if (strArray[0].match(/^file:\/\/\//)) {
-        strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///');
-    } else {
-        strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1://');
-    }
-
     for (let i = 0; i < strArray.length; i++) {
         let component = strArray[i];
 
@@ -52,6 +32,32 @@ function normalize(strArray) {
 
         resultArray.push(component);
     }
+    return resultArray;
+}
+
+function normalize(strArray) {
+    if (strArray.length === 0) {
+        return '';
+    }
+
+    if (typeof strArray[0] !== 'string') {
+        throw new TypeError(`Url must be a string. Received ${strArray[0]}`);
+    }
+
+    // If the first part is a plain protocol, we combine it with the next part.
+    if (strArray[0].match(/^[^/:]+:\/*$/) && strArray.length > 1) {
+        const first = strArray.shift();
+        strArray[0] = first + strArray[0];
+    }
+
+    // There must be two or three slashes in the file protocol, two slashes in anything else.
+    if (strArray[0].match(/^file:\/\/\//)) {
+        strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///');
+    } else {
+        strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1://');
+    }
+
+    const resultArray = joinLoop(strArray);
 
     let str = resultArray.join('/');
     // Each input component is now separated by a single slash except the possible first plain protocol part.

--- a/src/views/ServiceAccountList/ServiceAccountList.test.tsx
+++ b/src/views/ServiceAccountList/ServiceAccountList.test.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { render, fireEvent } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import '@testing-library/jest-dom';
+import Layout from '../../layouts/Layout';
+import { delay } from '../../testing/utils';
+import { ServiceAccountMeta } from '../../models/serviceaccount.model';
+import ServiceAccounts from '../../services/k8/serviceaccount.service';
+import ServiceAccountList from './ServiceAccountList';
+
+const generateServiceAccount = (name: string): ServiceAccountMeta => ({
+    name,
+    namespace: 'asdf',
+    uid: name,
+    createdAt: 0,
+    labels: { adsf: 'asdf' },
+    annotations: { asdf: 'asdf' },
+});
+
+const server = setupServer(
+    rest.get(`${ServiceAccounts.base}/*`, (req, res, ctx) => {
+        const count = 20;
+        const items = [];
+        for (let i = 0; i < count; i += 1) {
+            items.push(generateServiceAccount(`${i}-asdf`));
+        }
+        return res(
+            ctx.json({
+                items,
+                total: items.length,
+            })
+        );
+    })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('renders without crashing', async () => {
+    render(
+        <MemoryRouter initialEntries={['/']}>
+            <Routes>
+                <Route path="/" element={<Layout />}>
+                    <Route path="" element={<ServiceAccountList />} />
+                </Route>
+            </Routes>
+        </MemoryRouter>
+    );
+    await delay(500);
+});
+
+test('can go forwards and backwards in table', async () => {
+    const wrapper = render(
+        <MemoryRouter initialEntries={['/']}>
+            <Routes>
+                <Route path="/" element={<Layout />}>
+                    <Route path="" element={<ServiceAccountList />} />
+                </Route>
+            </Routes>
+        </MemoryRouter>
+    );
+
+    await delay(1000).then(async () => {
+        const forwardBtn = wrapper.getByTestId('next-page');
+        fireEvent.click(forwardBtn);
+        await delay(1000).then(() => {
+            const backwardBtn = wrapper.getByTestId('prev-page');
+            fireEvent.click(backwardBtn);
+        });
+    });
+});

--- a/src/views/ServiceAccountList/ServiceAccountList.tsx
+++ b/src/views/ServiceAccountList/ServiceAccountList.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { useNavContext } from '../../layouts/Navigation';
+import setOnce from '../../utils/breadcrumbs';
+import ServiceAccountTable from './ServiceAccountTable';
+
+export default function ServiceAccountList() {
+    const [, setState] = useNavContext();
+    setOnce(setState, {
+        breadcrumbs: [
+            {
+                text: 'service accounts',
+            },
+        ],
+        buttons: [],
+        menu: null,
+    });
+    return (
+        <div style={{ margin: '1em' }}>
+            <ServiceAccountTable />
+        </div>
+    );
+}

--- a/src/views/ServiceAccountList/ServiceAccountTable.tsx
+++ b/src/views/ServiceAccountList/ServiceAccountTable.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable react/no-unstable-nested-components */
+import { Card } from '@blueprintjs/core';
+import { Classes, Tooltip2 } from '@blueprintjs/popover2';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import ResourceTable from '../../components/ResourceTable';
+import { TableSort } from '../../components/SortableTableHeaderCell';
+import { Pagination } from '../../models/component.model';
+import { ServiceAccountMeta } from '../../models/serviceaccount.model';
+import K8 from '../../services/k8.service';
+import { buildLinkToNamespace } from '../../utils/routing';
+import getOffset from '../../utils/table';
+import { createdAtToHumanReadable, createdAtToOrigination } from '../../utils/time';
+
+interface IServiceAccountTableTableState extends Pagination {
+    serviceAccounts: ServiceAccountMeta[];
+    sort: TableSort;
+    pollId: NodeJS.Timer;
+}
+
+interface IServiceAccountTableProps {
+    namespace?: string;
+}
+
+class ServiceAccountTable extends React.Component<
+    IServiceAccountTableProps,
+    IServiceAccountTableTableState
+> {
+    constructor(props: IServiceAccountTableProps) {
+        super(props);
+        this.state = {
+            serviceAccounts: [],
+            sort: {
+                sortableId: 'name',
+                ascending: false,
+            },
+            page: 0,
+            pageSize: 10,
+            total: null,
+            pollId: null,
+        };
+    }
+
+    componentDidMount() {
+        K8.serviceAccounts
+            .getServiceAccounts(this.props.namespace, this.state.sort, 0, this.state.pageSize)
+            .then((response) => {
+                this.setState({
+                    serviceAccounts: response.data.items,
+                    total: response.data.total,
+                    pollId: K8.pollFunction(5000, () => this.pull(null, null)),
+                });
+            });
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.state.pollId);
+    }
+
+    pull = (sort?: TableSort, page?: number) => {
+        const usingSort = sort || this.state.sort;
+        const usingPage = page !== null ? page : this.state.page;
+        K8.serviceAccounts
+            .getServiceAccounts(
+                this.props.namespace,
+                usingSort,
+                getOffset(usingPage, this.state.pageSize, this.state.total),
+                this.state.pageSize
+            )
+            .then((response) => {
+                this.setState({
+                    serviceAccounts: response.data.items,
+                    sort: usingSort,
+                    page: usingPage,
+                    total: response.data.total,
+                });
+            });
+    };
+
+    sortChange = (sort: TableSort) => {
+        this.pull(sort, null);
+    };
+
+    setPage = (page: number) => {
+        this.pull(null, page);
+    };
+
+    render() {
+        return (
+            <Card style={{ padding: 0, minWidth: '40em' }}>
+                <ResourceTable<ServiceAccountMeta>
+                    paginationProps={{
+                        page: this.state.page,
+                        pageSize: this.state.pageSize,
+                        total: this.state.total,
+                        onPageChange: this.setPage,
+                    }}
+                    onSortChange={this.sortChange}
+                    sort={this.state.sort}
+                    data={this.state.serviceAccounts}
+                    keyPath="uid"
+                    columns={[
+                        {
+                            key: 'name',
+                            columnName: 'Name',
+                            sortableId: 'name',
+                            columnFunction: (row: ServiceAccountMeta) => row.name,
+                        },
+                        {
+                            key: 'namespace',
+                            columnName: 'Namespace',
+                            sortableId: 'namespace',
+                            columnFunction: (row: ServiceAccountMeta) => (
+                                <Link to={buildLinkToNamespace(row.namespace)}>
+                                    {row.namespace}
+                                </Link>
+                            ),
+                        },
+                        {
+                            key: 'age',
+                            columnName: 'Age',
+                            sortableId: 'created_at',
+                            columnFunction: (row: ServiceAccountMeta) => (
+                                <Tooltip2
+                                    className={Classes.TOOLTIP2_INDICATOR}
+                                    content={createdAtToOrigination(row.createdAt)}
+                                >
+                                    {createdAtToHumanReadable(row.createdAt)}
+                                </Tooltip2>
+                            ),
+                        },
+                    ]}
+                />
+            </Card>
+        );
+    }
+}
+
+export default ServiceAccountTable;

--- a/src/views/ServiceList/ServiceList.test.tsx
+++ b/src/views/ServiceList/ServiceList.test.tsx
@@ -10,8 +10,10 @@ import ServiceList from './ServiceList';
 import Services from '../../services/k8/service.service';
 import ServiceTable from './ServiceTable';
 import { delay } from '../../testing/utils';
+import Auth from '../../services/auth.service';
 
 const server = setupServer(
+    rest.get(`${Auth.base}/cani`, (req, res, ctx) => res(ctx.json({ allowed: true }))),
     rest.get(`${Services.base}/*`, (req, res, ctx) => {
         const count = 20;
         const items = [];


### PR DESCRIPTION
#### Fixes #11

#### Checklist

- [x] Includes tests

#### Changes proposed in this pull request:

* Adds cani endpoint
    * Takes verb, resource, name, and namespace
    * returns whether the user can access the resource using the verb
* Adds service accounts to backend
    * List and get
 * Adds service account table