### PR TITLE
override links to allow for custom context menu

### DIFF
--- a/src/components/ContainerSpec/ContainerSpecTableRow.tsx
+++ b/src/components/ContainerSpec/ContainerSpecTableRow.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { Button, Alignment, Menu, Position, MenuItem } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import { Link } from 'react-router-dom';
 import { useNavigate, useParams } from 'react-router';
 import { ContainerSpec } from '../../models/container.model';
 import { buildLinkToContainerSpec } from '../../utils/routing';
@@ -11,6 +10,7 @@ import TableRow from '../TableRow';
 import TableCell from '../TableCell';
 import PortTags from '../Port/PortTags';
 import ContainerSpecUpdateDialog from './ContainerSpecUpdateDialog';
+import Link from '../../layouts/Link';
 
 export default function ContainerSpecTableRow(props: {
     spec: ContainerSpec;

--- a/src/components/PodContainer.tsx
+++ b/src/components/PodContainer.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Colors, Card, Icon, Button, Position, Menu, MenuItem } from '@blueprintjs/core';
 import { Classes, Popover2, Tooltip2 } from '@blueprintjs/popover2';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Pod } from '../models/pod.model';
 import { createdAtToHumanReadable, createdAtToOrigination } from '../utils/time';
 import PodContainerTable from './PodContainerTable';

--- a/src/components/PodContainerTable.tsx
+++ b/src/components/PodContainerTable.tsx
@@ -3,7 +3,7 @@
 import { Alignment, Button, Card, Collapse, Colors, Icon, Menu, MenuItem } from '@blueprintjs/core';
 import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import Table from './Table';
 import TableCell from './TableCell';
 import TableHeader from './TableHeader';
@@ -14,6 +14,7 @@ import { buildLinkToContainer } from '../utils/routing';
 import { BytesTo } from '../utils/conversions';
 import ContainerSpecContainer from './ContainerSpec/ContainerSpecContainer';
 import CONSTANTS from '../utils/constants';
+import Link from '../layouts/Link';
 
 export default function PodContainerTable(props: { pod: Pod; accordion?: boolean }) {
     const getColor = (cont: Container) => {

--- a/src/layouts/Link.tsx
+++ b/src/layouts/Link.tsx
@@ -1,0 +1,41 @@
+import { ContextMenu2 } from '@blueprintjs/popover2';
+import { Link as RLink, useNavigate } from 'react-router-dom';
+import React from 'react';
+import { MenuItem, Menu } from '@blueprintjs/core';
+
+export default function Link(props: {
+    style?: React.CSSProperties;
+    to: string;
+    target?: string;
+    children?: React.ReactNode;
+}) {
+    const nav = useNavigate();
+    return (
+        <ContextMenu2
+            style={{ zIndex: 10000000000000, display: 'inline' }}
+            content={
+                <Menu>
+                    <MenuItem text="Open" onClick={() => nav(props.to)} />
+                    <MenuItem
+                        text="Open in new tab"
+                        onClick={() => {
+                            let url = props.to;
+                            if (!props.to.startsWith('/#')) {
+                                if (props.to.startsWith('/')) {
+                                    url = `/#${url}`;
+                                } else {
+                                    url = `/#/${url}`;
+                                }
+                            }
+                            window.open(url, '_blank');
+                        }}
+                    />
+                </Menu>
+            }
+        >
+            <RLink to={props.to} style={props.style} target={props.target}>
+                {props.children}
+            </RLink>
+        </ContextMenu2>
+    );
+}

--- a/src/layouts/Navigation.tsx
+++ b/src/layouts/Navigation.tsx
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import { Button, ButtonGroup, Card, Menu, Position } from '@blueprintjs/core';
 import { Popover2 } from '@blueprintjs/popover2';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import Link from './Link';
 
 export interface IBreadcrumb {
     text: string;

--- a/src/services/axios.service.tsx
+++ b/src/services/axios.service.tsx
@@ -23,7 +23,7 @@ export function getWSUrl(path: string): string {
 }
 
 export function convertToWSUrl(path: string): string {
-    return path.replace(window.location.protocol, 'ws:');
+    return path.replace('http:', 'ws:');
 }
 
 export function getBackendApiUrl(path: string): string {

--- a/src/services/k8/resource.service.ts
+++ b/src/services/k8/resource.service.ts
@@ -48,8 +48,10 @@ export default class Resource<M, F> {
     getNamespaceNameUrl = (params: ResourceGetParams) =>
         `${this.getNamespaceUrl(params)}/${params.name}`;
 
-    get = (params: ResourceGetParams): Promise<AxiosResponse<F>> =>
-        api.get(this.getNamespaceNameUrl(params));
+    get = (params: ResourceGetParams): Promise<AxiosResponse<F>> => {
+        console.log(this.getNamespaceNameUrl(params));
+        return api.get(this.getNamespaceNameUrl(params));
+    };
 
     list = (
         params: ResourceListParams = EMPTY_LIST_PARAMS
@@ -76,6 +78,11 @@ export default class Resource<M, F> {
     getWebsocket = (path: string, interval: number = 2500) =>
         new WS(convertToWSUrl(path), interval);
 
-    ws = (params: ResourceGetParams, interval: number = 1000): WS =>
-        this.getWebsocket(this.getNamespaceNameUrl(params).replace('/api/', '/ws/'), interval);
+    ws = (params: ResourceGetParams, interval: number = 1000): WS => {
+        console.log(this.getNamespaceNameUrl(params));
+        return this.getWebsocket(
+            this.getNamespaceNameUrl(params).replace('/api/', '/ws/'),
+            interval
+        );
+    };
 }

--- a/src/views/ClusterRoleBindingList/ClusterRoleBindingTable.tsx
+++ b/src/views/ClusterRoleBindingList/ClusterRoleBindingTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { ClusterRoleBindingMeta } from '../../models/clusterrole.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToClusterRoleBinding } from '../../utils/routing';

--- a/src/views/ClusterRoleList/ClusterRoleTable.tsx
+++ b/src/views/ClusterRoleList/ClusterRoleTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { ClusterRoleMeta } from '../../models/clusterrole.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToClusterRole } from '../../utils/routing';

--- a/src/views/DeploymentDetails/DeploymentDetails.tsx
+++ b/src/views/DeploymentDetails/DeploymentDetails.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/sort-comp */
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Button, Intent, MenuItem, Tag } from '@blueprintjs/core';
 import { IWithRouterProps, withRouter } from '../../utils/withRouter';
 import K8 from '../../services/k8.service';
@@ -18,6 +17,7 @@ import EditableResource from '../../components/EditableResource';
 import { buildLinkToReplicaSet } from '../../utils/routing';
 import Text from '../../components/Text/Text';
 import ResourceView from '../../components/ResourceView';
+import Link from '../../layouts/Link';
 
 interface IDeploymentDetailsState {
     isScaleDialogOpen: boolean;

--- a/src/views/DeploymentDetails/DeploymentServiceContainer.tsx
+++ b/src/views/DeploymentDetails/DeploymentServiceContainer.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { Colors, Card, Button, Position, Menu, MenuItem } from '@blueprintjs/core';
 import { Classes, Popover2, Tooltip2 } from '@blueprintjs/popover2';
-import { Link } from 'react-router-dom';
 import { createdAtToHumanReadable, createdAtToOrigination } from '../../utils/time';
 import Accordion from '../../components/Accordion';
 import { Service } from '../../models/service.model';
@@ -11,6 +10,7 @@ import TableHeader from '../../components/TableHeader';
 import TableCell from '../../components/TableCell';
 import TableRow from '../../components/TableRow';
 import { buildLinkToService } from '../../utils/routing';
+import Link from '../../layouts/Link';
 
 const createAccordionTitle = (service: Service): JSX.Element => (
     <div style={{ display: 'flex', alignItems: 'center' }}>

--- a/src/views/DeploymentList/DeploymentList.tsx
+++ b/src/views/DeploymentList/DeploymentList.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@blueprintjs/core';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import Link from '../../layouts/Link';
 import { useNavContext } from '../../layouts/Navigation';
 import setOnce from '../../utils/breadcrumbs';
 import DeploymentTable from './DeploymentTable';

--- a/src/views/DeploymentList/DeploymentTable.tsx
+++ b/src/views/DeploymentList/DeploymentTable.tsx
@@ -3,9 +3,9 @@
 import { Alignment, Colors, Icon } from '@blueprintjs/core';
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { DeploymentMeta } from '../../models/deployment.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToDeployment, buildLinkToNamespace } from '../../utils/routing';

--- a/src/views/HelmChart/HelmChart.tsx
+++ b/src/views/HelmChart/HelmChart.tsx
@@ -6,7 +6,6 @@ import '../../styles/markdown.scss';
 import { Intent, Spinner, Card, Tag, Button } from '@blueprintjs/core';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { Link } from 'react-router-dom';
 import React from 'react';
 import TitledCard from '../../components/Cards/TitledCard';
 import Text from '../../components/Text/Text';
@@ -16,6 +15,7 @@ import Helm from '../../services/helm.service';
 import LabeledText from '../../components/LabeledText';
 import { IBreadcrumb, NavContext } from '../../layouts/Navigation';
 import TagList from '../../components/TagList';
+import Link from '../../layouts/Link';
 
 interface IHelmChartState {
     chart: Chart;

--- a/src/views/HelmRelease/HelmRelease.tsx
+++ b/src/views/HelmRelease/HelmRelease.tsx
@@ -5,7 +5,6 @@
 /* eslint-disable react/prefer-stateless-function */
 import '../../styles/markdown.scss';
 import { Card, Intent, Spinner } from '@blueprintjs/core';
-import { Link } from 'react-router-dom';
 import React from 'react';
 import TitledCard from '../../components/Cards/TitledCard';
 import Text from '../../components/Text/Text';
@@ -21,6 +20,7 @@ import TableCell from '../../components/TableCell';
 import TableBody from '../../components/TableBody';
 import TableRow from '../../components/TableRow';
 import { buildGenericLink } from '../../utils/routing';
+import Link from '../../layouts/Link';
 
 interface IHelmReleaseState {
     release: Release;

--- a/src/views/HelmReleaseList/HelmReleaseTable.tsx
+++ b/src/views/HelmReleaseList/HelmReleaseTable.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/alt-text */
 /* eslint-disable class-methods-use-this */
 import { Intent, Spinner, Tag } from '@blueprintjs/core';
-import { Link } from 'react-router-dom';
 import React from 'react';
 import Text from '../../components/Text/Text';
 import { TableSort } from '../../components/SortableTableHeaderCell';
@@ -9,6 +8,7 @@ import ResourceTableView from '../../components/ResourceTableView';
 import Helm from '../../services/helm.service';
 import getOffset from '../../utils/table';
 import { Release } from '../../models/helm.model';
+import Link from '../../layouts/Link';
 
 class HelmReleaseTable extends ResourceTableView<unknown, Release> {
     itemsFcn = Helm.queryReleases;

--- a/src/views/HelmSearch/HelmChartTable.tsx
+++ b/src/views/HelmSearch/HelmChartTable.tsx
@@ -2,13 +2,13 @@
 /* eslint-disable class-methods-use-this */
 import { Intent, Spinner, Card, InputGroup, Tag } from '@blueprintjs/core';
 import React from 'react';
-import { Link } from 'react-router-dom';
 import Text from '../../components/Text/Text';
 import { TableSort } from '../../components/SortableTableHeaderCell';
 import ResourceTableView from '../../components/ResourceTableView';
 import { Chart } from '../../models/helm.model';
 import Helm from '../../services/helm.service';
 import getOffset from '../../utils/table';
+import Link from '../../layouts/Link';
 
 class HelmChartTable extends ResourceTableView<unknown, Chart> {
     itemsFcn = Helm.queryCharts;

--- a/src/views/NamespaceList/NamespaceTable.tsx
+++ b/src/views/NamespaceList/NamespaceTable.tsx
@@ -2,13 +2,13 @@
 import { Card } from '@blueprintjs/core';
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTable, {
     DEFAULT_SORTABLE_ASCENDING,
     DEFAULT_SORTABLE_ID,
     DEFAULT_SORTABLE_PAGE_SIZE,
 } from '../../components/ResourceTable';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { Pagination } from '../../models/component.model';
 import { NamespaceMeta } from '../../models/namespace.model';
 import K8 from '../../services/k8.service';

--- a/src/views/NodeList/NodeTable.tsx
+++ b/src/views/NodeList/NodeTable.tsx
@@ -1,11 +1,11 @@
 import { Card, Tag } from '@blueprintjs/core';
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import Table from '../../components/Table';
 import TableCell from '../../components/TableCell';
 import TableHeader from '../../components/TableHeader';
 import TableRow from '../../components/TableRow';
+import Link from '../../layouts/Link';
 import { NodeMeta } from '../../models/node.model';
 import K8 from '../../services/k8.service';
 import { BytesTo } from '../../utils/conversions';

--- a/src/views/PodContainerDetails/PodContainerDetails.tsx
+++ b/src/views/PodContainerDetails/PodContainerDetails.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable @typescript-eslint/lines-between-class-members */
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Button } from '@blueprintjs/core';
 import { IWithRouterProps, withRouter } from '../../utils/withRouter';
 import K8 from '../../services/k8.service';
@@ -10,6 +9,7 @@ import { IBreadcrumb, NavContext } from '../../layouts/Navigation';
 import PodContainerInfoCard from './PodContainerInfoCard';
 import Accordion from '../../components/Accordion';
 import { buildLinkToContainer } from '../../utils/routing';
+import Link from '../../layouts/Link';
 
 interface IPodContainerState {
     container: Container;

--- a/src/views/PodDetails/PodDetails.tsx
+++ b/src/views/PodDetails/PodDetails.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/static-property-placement */
 import * as React from 'react';
 import { Button } from '@blueprintjs/core';
-import { Link } from 'react-router-dom';
 import { IWithRouterProps, withRouter } from '../../utils/withRouter';
 import K8 from '../../services/k8.service';
 import { Pod } from '../../models/pod.model';
@@ -19,6 +18,7 @@ import Details from './Tabs/Details';
 import Prometheus from '../../services/prometheus.service';
 import Metrics from './Tabs/Metrics';
 import ResourceView from '../../components/ResourceView';
+import Link from '../../layouts/Link';
 
 class PodDetails extends ResourceView<Pod, IWithRouterProps, {}> {
     static contextType = NavContext;

--- a/src/views/PodList/PodListTable.tsx
+++ b/src/views/PodList/PodListTable.tsx
@@ -2,10 +2,10 @@
 import { Alignment, Icon } from '@blueprintjs/core';
 import { Tooltip2, Classes } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import AgeText from '../../components/AgeText';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { PodMeta } from '../../models/pod.model';
 import K8 from '../../services/k8.service';
 import { getStatusColor } from '../../utils/pods';

--- a/src/views/ReplicaSetDetails/ReplicaSetDetails.tsx
+++ b/src/views/ReplicaSetDetails/ReplicaSetDetails.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/static-property-placement */
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Button, Card, Intent, MenuItem, Tag } from '@blueprintjs/core';
 import { IWithRouterProps, withRouter } from '../../utils/withRouter';
 import K8 from '../../services/k8.service';
@@ -23,6 +22,7 @@ import TableRow from '../../components/TableRow';
 import EventTable from '../../components/EventTable';
 import Toaster from '../../services/toast.service';
 import ResourceView from '../../components/ResourceView';
+import Link from '../../layouts/Link';
 
 class ReplicaSetDetails extends ResourceView<ReplicaSet, IWithRouterProps, {}> {
     constructor(props: IWithRouterProps) {

--- a/src/views/ReplicaSetList/ReplicaSetTable.tsx
+++ b/src/views/ReplicaSetList/ReplicaSetTable.tsx
@@ -3,9 +3,9 @@
 import { Alignment, Colors, Icon } from '@blueprintjs/core';
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { ReplicaSetMeta } from '../../models/replicaset.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToNamespace, buildLinkToReplicaSet } from '../../utils/routing';

--- a/src/views/RoleBindingList/RoleBindingTable.tsx
+++ b/src/views/RoleBindingList/RoleBindingTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { RoleBindingMeta } from '../../models/role.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToNamespace, buildLinkToRoleBinding } from '../../utils/routing';

--- a/src/views/RoleList/RoleTable.tsx
+++ b/src/views/RoleList/RoleTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { RoleMeta } from '../../models/role.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToNamespace, buildLinkToRole } from '../../utils/routing';

--- a/src/views/SecretList/SecretTable.tsx
+++ b/src/views/SecretList/SecretTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { SecretMeta } from '../../models/secret.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToNamespace, buildLinkToSecret } from '../../utils/routing';

--- a/src/views/ServiceAccountDetails/ServiceAccountDetails.tsx
+++ b/src/views/ServiceAccountDetails/ServiceAccountDetails.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { Alignment, Button, Card, Intent } from '@blueprintjs/core';
 import { AxiosError } from 'axios';
 import { Tooltip2, Classes } from '@blueprintjs/popover2';
-import { Link } from 'react-router-dom';
 import { IWithRouterProps, withRouter } from '../../utils/withRouter';
 import K8 from '../../services/k8.service';
 import { IBreadcrumb, NavContext } from '../../layouts/Navigation';
@@ -32,6 +31,7 @@ import RoleBindDialog from './RoleBindDialog';
 import ClusterRoleBindDialog from './ClusterRoleBindDialog';
 import EditableResource from '../../components/EditableResource';
 import ResourceView from '../../components/ResourceView';
+import Link from '../../layouts/Link';
 
 interface IServiceAccountDetailsState {
     isRoleBindOpen: boolean;

--- a/src/views/ServiceAccountList/ServiceAccountTable.tsx
+++ b/src/views/ServiceAccountList/ServiceAccountTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { ServiceAccountMeta } from '../../models/serviceaccount.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToNamespace, buildLinkToServiceAccount } from '../../utils/routing';

--- a/src/views/ServiceList/ServiceTable.tsx
+++ b/src/views/ServiceList/ServiceTable.tsx
@@ -2,9 +2,9 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { Classes, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import ResourceTableView, { IResourceTableViewProps } from '../../components/ResourceTableView';
 import { TableSort } from '../../components/SortableTableHeaderCell';
+import Link from '../../layouts/Link';
 import { ServiceMeta } from '../../models/service.model';
 import K8 from '../../services/k8.service';
 import { buildLinkToNamespace, buildLinkToService } from '../../utils/routing';


### PR DESCRIPTION
#### Fixes #63 

#### Checklist

- [ ] Includes tests

#### Changes proposed in this pull request:

Overrides react-router-dom links to have custom context menu - in preparation for tabs
